### PR TITLE
fix: ruta del modulo de mantenimientos

### DIFF
--- a/frontend/src/modules/Mantenimientos/MantenimientosList.jsx
+++ b/frontend/src/modules/Mantenimientos/MantenimientosList.jsx
@@ -1,18 +1,18 @@
 import { useState, useEffect } from "react";
-import { getCamiones } from "../../services/mantenimientosService";
+import { getMantenimientos } from "../../services/mantenimientosService";
 
-export default function CamionesList() {
-  const [camiones, setCamiones] = useState([]);
+export default function MantenimientosList() {
+  const [mantenimientos, setMantenimientos] = useState([]);
 
   useEffect(() => {
-    getCamiones().then(setCamiones);
+    getMantenimientos().then(setMantenimientos);
   }, []);
 
   return (
     <div>
-      <h2>Camiones</h2>
+      <h2>Mantenimientos</h2>
       <ul>
-        {camiones.map(c => (
+        {mantenimientos.map(c => (
           <li key={c.id}>{c.camion} {c.estado}</li>
         ))}
       </ul>

--- a/frontend/src/services/mantenimientosService.js
+++ b/frontend/src/services/mantenimientosService.js
@@ -1,6 +1,6 @@
 import api from "./api";
 
-export const getCamiones = async () => {
+export const getMantenimientos = async () => {
   const res = await api.get("/mantenimientos");
   return res.data;
 };


### PR DESCRIPTION
Fix: mantenimientoList.jsx y mantenimientoServices.js

      - Se arreglo la sintaxis de las constantes y funciones, estaban definidas como getCamiones, al igual que el titulo h2 estaba definido en Camiones, por lo tanto se ajusto todo lo necesario a estos dos archivos para corregir la nomenclatura y sintaxis que debia ser correspondiente a mantenimientos.