### PR TITLE
fix cambio en la api  para que use el de railway   El frontend está configurado para usar localhost:4000 en lugar de la URL de Railway.

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: "http://localhost:4000/api",
+  baseURL: "/api",
 });
 
 // Interceptor para agregar el token a todas las peticiones


### PR DESCRIPTION
 El frontend está configurado para usar localhost:4000 en lugar de la URL de Railway.